### PR TITLE
fix: sun_roof

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -899,7 +899,7 @@ class AudiConnectVehicle:
     @property
     def sun_roof(self):
         if self.sun_roof_supported:
-            return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")           
+            return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
 
     @property
     def sun_roof_supported(self):

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -899,13 +899,12 @@ class AudiConnectVehicle:
     @property
     def sun_roof(self):
         if self.sun_roof_supported:
-            res = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
-            return res == "2"
+            return self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")           
 
     @property
     def sun_roof_supported(self):
         check = self._vehicle.fields.get("STATE_SUN_ROOF_MOTOR_COVER")
-        if check and check != "0":
+        if check is not None:
             return True
 
     @property


### PR DESCRIPTION
Currently we get only a sun roof state in Home-Assitant if sun_roof is closed (3)

""value": "3" if status[0] == "closed" else "0""